### PR TITLE
Add duplicate player guard to players API

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,3 +309,18 @@ The `/backend` directory contains an Express server that mirrors parts of the AP
 3. Run the development server with `npm run dev` (from `/frontend`), which starts the Next.js app at `http://localhost:3000`.
 4. Apply database migrations via `npx prisma migrate dev` when schema changes occur.
 5. Use Supabase Studio or Prisma Studio (`npx prisma studio`) to inspect data during development.
+
+## Manual Verification
+
+The `/api/players` route now checks for an existing player with the same trimmed `name` before creating a new record. To verify the behavior manually:
+
+1. Start the frontend development server: `npm run dev:frontend`.
+2. Create a player:
+   - `curl -i -X POST http://localhost:3000/api/players \
+       -H "Content-Type: application/json" \
+       -d '{"name":"Test Player","email":"test@example.com"}'`
+   - Expect a `201 Created` response containing the new player JSON body.
+3. Repeat the same request using the identical `name` value.
+   - Expect a `409 Conflict` response with `{ "error": "Player already exists." }`.
+
+These steps cover both the successful creation and the conflict response introduced in this update.

--- a/frontend/src/app/api/players/route.ts
+++ b/frontend/src/app/api/players/route.ts
@@ -19,10 +19,21 @@ export async function POST(request: Request) {
   try {
     const body = await request.json();
     const { name, email, phone, status = "ACTIVE", paymentStatus = "BELUM_SETOR" } = body;
+    const trimmedName = typeof name === "string" ? name.trim() : "";
+
+    const existingPlayer = await prisma.player.findFirst({
+      where: {
+        name: trimmedName,
+      },
+    });
+
+    if (existingPlayer) {
+      return NextResponse.json({ error: "Player already exists." }, { status: 409 });
+    }
 
     const player = await prisma.player.create({
       data: {
-        name,
+        name: trimmedName,
         email,
         phone,
         status,


### PR DESCRIPTION
## Summary
- trim incoming player names in the POST /api/players handler and look up existing records before inserting
- return a 409 conflict with an error payload when the name already exists
- document manual verification steps covering the success and conflict scenarios

## Testing
- Manual verification steps added to the README

------
https://chatgpt.com/codex/tasks/task_e_68da887682b08325a57ef8a3dfc9719b