### PR TITLE
Hide existing player search results list

### DIFF
--- a/frontend/src/components/MatchDetailsModal.tsx
+++ b/frontend/src/components/MatchDetailsModal.tsx
@@ -496,23 +496,7 @@ export default function MatchDetailsModal({
                           className="form-input"
                           aria-label="Search existing players"
                         />
-                        {filteredExistingPlayers.length > 0 ? (
-                          <div className="existing-players-list">
-                            {filteredExistingPlayers.map((player) => (
-                              <div key={player.id} className="existing-player-item">
-                                <span>{player.name}</span>
-                                <button
-                                  onClick={() => handleAddPlayer(player.id)}
-                                  className="add-player-btn-small"
-                                >
-                                  Add
-                                </button>
-                              </div>
-                            ))}
-                          </div>
-                        ) : (
-                          <p className="no-players">No matching players found.</p>
-                        )}
+                        {/* Existing player list temporarily hidden until search improvements are implemented */}
                       </>
                     ) : (
                       <p className="no-players">No players found in recent matches.</p>


### PR DESCRIPTION
## Summary
- temporarily hide the existing player search results list in the match details modal while the search is unreliable

## Testing
- npm run dev *(fails: supabaseUrl is required in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db656412f0832593a4ff59e9ba7cf0