### PR TITLE
Show message for existing match players in search results

### DIFF
--- a/frontend/src/components/MatchDetailsModal.tsx
+++ b/frontend/src/components/MatchDetailsModal.tsx
@@ -272,6 +272,7 @@ export default function MatchDetailsModal({
         await fetchCurrentPlayers();
         await fetchPastPlayers();
         onMatchUpdate?.();
+        setExistingPlayerSearch("");
       }
     } catch (error) {
       console.error("Error adding player:", error);
@@ -430,6 +431,16 @@ export default function MatchDetailsModal({
     });
   }, [availablePastPlayers, existingPlayerSearch]);
 
+  const isPlayerAlreadyInMatch = useMemo(() => {
+    const searchTerm = existingPlayerSearch.trim().toLowerCase();
+
+    if (!searchTerm) {
+      return false;
+    }
+
+    return players.some((player) => player.name.toLowerCase().includes(searchTerm));
+  }, [existingPlayerSearch, players]);
+
   const activePlayers = useMemo(
     () => players.filter((player) => player.status === "ACTIVE"),
     [players],
@@ -526,6 +537,8 @@ export default function MatchDetailsModal({
                                 </button>
                               ))}
                             </div>
+                          ) : isPlayerAlreadyInMatch ? (
+                            <p className="no-players">Player is in the match.</p>
                           ) : (
                             <p className="no-players">No matching players found.</p>
                           )


### PR DESCRIPTION
## Summary
- clear the existing-player search input after adding a player to a match
- detect when a searched player is already part of the match and show a dedicated message instead of the generic no-results text

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68db6ef5468483259005cb9be76e00de